### PR TITLE
Prevent crash if ActiveRecord is not included

### DIFF
--- a/lib/liquid-rails/railtie.rb
+++ b/lib/liquid-rails/railtie.rb
@@ -19,7 +19,7 @@ module Liquid
           ActiveSupport.on_load orm do
             Liquid::Rails.setup_drop self
 
-            if self == ActiveRecord::Base
+            if defined?(ActiveRecord) && self == ActiveRecord::Base
               Liquid::Rails.setup_drop(ActiveRecord::Relation)
             end
           end


### PR DESCRIPTION
In my project I didn't require `active_record/railtie`, so It will crash when the gem trying to setup drop with active record relation